### PR TITLE
Remove Cloudflare DNS

### DIFF
--- a/pkg/massdns/massdns.go
+++ b/pkg/massdns/massdns.go
@@ -46,6 +46,8 @@ type Config struct {
 var excellentResolvers = []string{
 	"8.8.8.8",
 	"8.8.4.4",
+	"208.67.222.222",
+	"208.67.220.220",
 }
 
 // New returns a new massdns client for running enumeration

--- a/pkg/massdns/massdns.go
+++ b/pkg/massdns/massdns.go
@@ -44,8 +44,6 @@ type Config struct {
 
 // excellentResolvers contains some resolvers used in dns verification step
 var excellentResolvers = []string{
-	"1.1.1.1",
-	"1.0.0.1",
 	"8.8.8.8",
 	"8.8.4.4",
 }


### PR DESCRIPTION
Cloudflare DNS drops requests because of rate limit which leads to false negatives