### PR TITLE
Fix and optimize Dockerfile

### DIFF
--- a/.github/workflows/cicd-to-dockerhub.yml
+++ b/.github/workflows/cicd-to-dockerhub.yml
@@ -1,0 +1,37 @@
+
+name: cicd-to-dockerhub
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/shuffledns:latest
+          
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,32 @@
-FROM golang:1.14-alpine as build
-RUN apk --no-cache add git
-RUN go get -u -v github.com/projectdiscovery/shuffledns/cmd/shuffledns; exit 0
-ENV GO111MODULE on
-WORKDIR github.com/projectdiscovery/shuffledns/cmd/shuffledns
-RUN go install ./...
+# Build image: golang:1.14-alpine3.13
+FROM golang@sha256:ef409ff24dd3d79ec313efe88153d703fee8b80a522d294bb7908216dc7aa168 as build
 
-FROM alpine:latest
-RUN apk --update --no-cache add ldns \
+# Pull and install massdns
+RUN apk --no-cache add git ldns \
   && apk --no-cache --virtual .deps add ldns-dev \
                                         git \
                                         build-base \
   && git clone --branch=master \
                --depth=1 \
-               https://github.com/blechschmidt/massdns.git \
-  && cd massdns \
-  && make \
-  && mv bin/massdns /usr/bin/massdns \
-  && rm -rf /massdns \
-  && apk del .deps
+               https://github.com/blechschmidt/massdns.git /massdns \
+  && cd /massdns \
+  && make
 
-COPY --from=build /go/bin/shuffledns /usr/bin/shuffledns
-ENV HOME /
+# Pull and install ShuffleDNS
+RUN go get -u -v github.com/projectdiscovery/shuffledns/cmd/shuffledns; exit 0
+WORKDIR src/github.com/projectdiscovery/shuffledns/cmd/shuffledns
+RUN GO111MODULE=on go install ./...
+
+# Release Image: alpine:3.14.1
+FROM alpine@sha256:be9bdc0ef8e96dbc428dc189b31e2e3b05523d96d12ed627c37aa2936653258c
+
+COPY --from=build /go/bin/shuffledns /massdns/bin/massdns /usr/bin/
+
+RUN adduser \
+    --gecos "" \
+    --disabled-password \
+    shuffledns
+
+USER shuffledns
+
 ENTRYPOINT ["/usr/bin/shuffledns"]


### PR DESCRIPTION
This PR fixes and modifies the Dockerfile in ShuffleDNS with the following considerations:
- The current Dockerfile does not work due to a small mistake in the WORKDIR directive. Fixed.
- The current Dockerfile does not leverage multi-stage builds. The fixed image has about 660MB with the current Dockerfile instructions. With multi-stage build it has about 13MB.
- Adds deterministic base images for reproducible builds.
- Added a least-privileged user in compliance with Docker security best practices.

We also have a workflow with a CICD pipeline to DockerHub. All you need to do is to add the DOCKER_HUB_USERNAME and DOCKER_HUB_ACCESS_TOKEN secrets to the repository and all pushes/merges to the master branch will automatically push an image to DockerHub.