### PR TITLE
Allows massdns to run as root via --root param

### DIFF
--- a/pkg/massdns/massdns.go
+++ b/pkg/massdns/massdns.go
@@ -40,6 +40,8 @@ type Config struct {
 	MassdnsRaw string
 	// StrictWildcard controls whether the wildcard check should be performed on each result
 	StrictWildcard bool
+	// AllowRoot allows massdns to run as root via --root param
+	AllowRoot bool
 }
 
 // excellentResolvers contains some resolvers used in dns verification step

--- a/pkg/massdns/process.go
+++ b/pkg/massdns/process.go
@@ -88,8 +88,12 @@ func (c *Client) runMassDNS(output string, store *store.Store) error {
 		gologger.Infof("Executing massdns\n")
 	}
 	now := time.Now()
+	args := []string{"-r", c.config.ResolversFile, "-o", "Snl", "-t", "A", c.config.InputFile, "-w", output, "-s", strconv.Itoa(c.config.Threads)}
+	if c.config.AllowRoot {
+		args = append(args, "--root")
+	}
 	// Run the command on a temp file and wait for the output
-	cmd := exec.Command(c.config.MassdnsPath, []string{"-r", c.config.ResolversFile, "-o", "Snl", "-t", "A", c.config.InputFile, "-w", output, "-s", strconv.Itoa(c.config.Threads)}...)
+	cmd := exec.Command(c.config.MassdnsPath, args...)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	err := cmd.Run()

--- a/pkg/runner/options.go
+++ b/pkg/runner/options.go
@@ -29,6 +29,7 @@ type Options struct {
 	MassdnsRaw      string // MassdnsRaw perform wildcards filtering from an existing massdns output file
 	WildcardThreads int    // WildcardsThreads controls the number of parallel host to check for wildcard
 	StrictWildcard  bool   // StrictWildcard flag indicates whether wildcard check has to be performed on each found subdomains
+	AllowRoot       bool   // AllowRoot allows massdns to run as root user via --root param
 
 	Stdin bool // Stdin specifies whether stdin input was given to the process
 }
@@ -53,6 +54,7 @@ func ParseOptions() *Options {
 	flag.StringVar(&options.MassdnsRaw, "raw-input", "", "Validate raw full massdns output")
 	flag.BoolVar(&options.StrictWildcard, "strict-wildcard", false, "Perform wildcard check on all found subdomains")
 	flag.IntVar(&options.WildcardThreads, "wt", 25, "Number of concurrent wildcard checks")
+	flag.BoolVar(&options.AllowRoot, "root", false, "Allow to run as root user")
 
 	flag.Parse()
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -182,6 +182,7 @@ func (r *Runner) runMassdns(inputFile string) {
 		OutputFile:       r.options.Output,
 		MassdnsRaw:       r.options.MassdnsRaw,
 		StrictWildcard:   r.options.StrictWildcard,
+		AllowRoot:        r.options.AllowRoot,
 	})
 	if err != nil {
 		gologger.Errorf("Could not create massdns client: %s\n", err)


### PR DESCRIPTION
Hi there,

This pull request adds a param `--root` to shuffledns. If users use this param, it will pass to massdns in order to bypass its security warning.