### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The tool also needs a list of valid resolvers. The [dnsvalidator](https://github
 shuffledns requires `go1.14+` to install successfully. Run the following command to get the repo - 
 
 ```bash
-▶ GO111MODULE=on go get -v github.com/projectdiscovery/shuffledns/cmd/shuffledns
+▶ GO111MODULE=on go install -v github.com/projectdiscovery/shuffledns/cmd/shuffledns@latest
 ```
 
 ## Running shuffledns


### PR DESCRIPTION
Installing executables with "go get" in module mode is deprecated.
"go install pkg@version" should be used instead.
For more information, see https://golang.org/doc/go-get-install-deprecation