### PR TITLE
Updating dockerfile with go17 syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
-FROM golang:1.17-alpine as build
+FROM golang:1.17.3-alpine as build-env
 RUN apk --no-cache add git
-RUN go get -u -v github.com/projectdiscovery/shuffledns/cmd/shuffledns; exit 0
-ENV GO111MODULE on
-WORKDIR github.com/projectdiscovery/shuffledns/cmd/shuffledns
-RUN go install ./...
+RUN go install -v github.com/projectdiscovery/shuffledns/cmd/shuffledns@latest
 
-FROM alpine:3.15.0
+FROM alpine:3.14
 RUN apk --update --no-cache add ldns \
   && apk --no-cache --virtual .deps add ldns-dev \
                                         git \
@@ -19,6 +16,6 @@ RUN apk --update --no-cache add ldns \
   && rm -rf /massdns \
   && apk del .deps
 
-COPY --from=build /go/bin/shuffledns /usr/bin/shuffledns
+COPY --from=build-env /go/bin/shuffledns /usr/bin/shuffledns
 ENV HOME /
 ENTRYPOINT ["/usr/bin/shuffledns"]


### PR DESCRIPTION
```console
$ docker build .
[+] Building 42.1s (11/11) FINISHED                                                                                                                                                                                                                                                                                
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                                          0.0s
 => => transferring dockerfile: 735B                                                                                                                                                                                                                                                                          0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                                                               0.0s
 => [internal] load metadata for docker.io/library/alpine:3.14                                                                                                                                                                                                                                                1.4s
 => [internal] load metadata for docker.io/library/golang:1.17.3-alpine                                                                                                                                                                                                                                       1.9s
 => [build-env 1/3] FROM docker.io/library/golang:1.17.3-alpine@sha256:a207b29286084e7342286de809756f61558b00b81f794406399027631e0dba8b                                                                                                                                                                      24.2s
 => => resolve docker.io/library/golang:1.17.3-alpine@sha256:a207b29286084e7342286de809756f61558b00b81f794406399027631e0dba8b                                                                                                                                                                                 0.0s
 => => sha256:33730119e82d830083e1be6f0c3061caab12842c714704bdc1a172bb54f7b33f 1.36kB / 1.36kB                                                                                                                                                                                                                0.0s
 => => sha256:861f73fe2c7f31dfd8cb97cd183393e76f902db2f9008c1293e2d8b34678ebb8 5.20kB / 5.20kB                                                                                                                                                                                                                0.0s
 => => sha256:59bf1c3509f33515622619af21ed55bbe26d24913cedbca106468a5fb37a50c3 2.82MB / 2.82MB                                                                                                                                                                                                                0.6s
 => => sha256:666ba61612fd7c93393f9a5bc1751d8a9929e32d51501dba691da9e8232bc87b 282.16kB / 282.16kB                                                                                                                                                                                                            0.6s
 => => sha256:8ed8ca4862056a130f714accb3538decfa0663fec84e635d8b5a0a3305353dee 155B / 155B                                                                                                                                                                                                                    0.6s
 => => sha256:a207b29286084e7342286de809756f61558b00b81f794406399027631e0dba8b 1.65kB / 1.65kB                                                                                                                                                                                                                0.0s
 => => sha256:bfe7d510f5225716e23f112aa0f9a19ba47c87fc22888c74bde73a32f06167a4 110.12MB / 110.12MB                                                                                                                                                                                                           16.8s
 => => extracting sha256:59bf1c3509f33515622619af21ed55bbe26d24913cedbca106468a5fb37a50c3                                                                                                                                                                                                                     0.3s
 => => sha256:560f678454b3736bd0a5429b3beafb27808cbc44489ff7d3e2165689b0f2e6cf 156B / 156B                                                                                                                                                                                                                    0.8s
 => => extracting sha256:666ba61612fd7c93393f9a5bc1751d8a9929e32d51501dba691da9e8232bc87b                                                                                                                                                                                                                     0.2s
 => => extracting sha256:8ed8ca4862056a130f714accb3538decfa0663fec84e635d8b5a0a3305353dee                                                                                                                                                                                                                     0.0s
 => => extracting sha256:bfe7d510f5225716e23f112aa0f9a19ba47c87fc22888c74bde73a32f06167a4                                                                                                                                                                                                                     6.9s
 => => extracting sha256:560f678454b3736bd0a5429b3beafb27808cbc44489ff7d3e2165689b0f2e6cf                                                                                                                                                                                                                     0.0s
 => [stage-1 1/3] FROM docker.io/library/alpine:3.14@sha256:635f0aa53d99017b38d1a0aa5b2082f7812b03e3cdb299103fe77b5c8a07f1d2                                                                                                                                                                                  0.0s
 => [build-env 2/3] RUN apk --no-cache add git                                                                                                                                                                                                                                                                3.0s
 => [build-env 3/3] RUN go install -v github.com/projectdiscovery/shuffledns/cmd/shuffledns@latest                                                                                                                                                                                                           12.8s
 => CACHED [stage-1 2/3] RUN apk --update --no-cache add ldns   && apk --no-cache --virtual .deps add ldns-dev                                         git                                         build-base   && git clone --branch=master                --depth=1                https://github.com/blec  0.0s
 => [stage-1 3/3] COPY --from=build-env /go/bin/shuffledns /usr/bin/shuffledns                                                                                                                                                                                                                                0.1s
 => exporting to image                                                                                                                                                                                                                                                                                        0.1s
 => => exporting layers                                                                                                                                                                                                                                                                                       0.1s
 => => writing image sha256:911fede3f20a0ee0375e255c7a0709554f04272b0b933eae36f2df42428f1ff8
```