### PR TITLE
Fixing stdin logic (use Stdin if SubdomainsList is blank)

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -150,7 +150,7 @@ func (r *Runner) processSubdomains() {
 	var resolveFile string
 
 	// If there is stdin, write the resolution list to the file
-	if r.options.Stdin {
+	if r.options.Stdin && r.options.SubdomainsList == "" {
 		resolveFile = filepath.Join(r.tempDir, xid.New().String())
 		file, err := os.Create(resolveFile)
 		if err != nil {


### PR DESCRIPTION
`subfinder -d example.com | shuffledns -list example-subdomains.txt  -d example.com -r resolvers.txt `
I expect this command to use **example-subdomains.txt**  but it uses STDIN(subfinder -d example.com)