### PR TITLE
handle multiple output case

### DIFF
--- a/pkg/massdns/process.go
+++ b/pkg/massdns/process.go
@@ -52,7 +52,7 @@ func (c *Client) Process() error {
 	// Check if we need to run massdns
 	if c.config.MassdnsRaw == "" {
 		// Create a temporary file for the massdns output
-		gologger.Info().Msgf("Creating temporary massdns output file: %s\n", massDNSOutput)
+		gologger.Info().Msgf("Creating temporary massdns output directory: %s\n", tmpDir)
 		err = c.runMassDNS(massDNSOutput, shstore)
 		if err != nil {
 			return fmt.Errorf("could not execute massdns: %w", err)


### PR DESCRIPTION
Closes #260

before:
```console
$ go run . -d example.com -list example-subdomains.txt -r resolvers.txt -t 35 -mcmd '--processes 2'

       __        ________        __       
  ___ / /  __ __/ _/ _/ /__  ___/ /__ ___
 (_-</ _ \/ // / _/ _/ / -_)/ _  / _ \(_-<
/___/_//_/\_,_/_//_//_/\__/ \_,_/_//_/___/

                projectdiscovery.io

[INF] Current shuffledns version v1.0.9 (latest)
[INF] Creating temporary massdns output file: /var/folders/hx/f8qcbgj91795xdrdnb55qkdc0000gn/T/shuffledns-1057597848/cmtnemfa2ua2oc3ud9ag
[INF] Executing massdns on example.com
[INF] Massdns execution took 2.006099084s
[INF] Started parsing massdns output
[ERR] Could not run massdns: could not parse massdns output: could not open massdns output file: open /var/folders/hx/f8qcbgj91795xdrdnb55qkdc0000gn/T/shuffledns-1057597848/cmtnemfa2ua2oc3ud9ag: no such file or directory
[INF] Finished resolving. Hack the Planet!
```

after:
```console
$ go run . -d example.com -list example-subdomains.txt -r resolvers.txt -t 35 -mcmd '--processes 2'

       __        ________        __       
  ___ / /  __ __/ _/ _/ /__  ___/ /__ ___
 (_-</ _ \/ // / _/ _/ / -_)/ _  / _ \(_-<
/___/_//_/\_,_/_//_//_/\__/ \_,_/_//_/___/

                projectdiscovery.io

[INF] Current shuffledns version v1.0.9 (latest)
[INF] Creating temporary massdns output file: /var/folders/hx/f8qcbgj91795xdrdnb55qkdc0000gn/T/shuffledns-3866732922/cmtne3na2ua2l2fs27ng
[INF] Executing massdns on example.com
[INF] Massdns execution took 1.878241333s
[INF] Started parsing massdns output
[INF] Massdns output parsing completed
[INF] Started removing wildcards records
[INF] Wildcard removal completed
[INF] Finished enumeration, started writing output
localhost
[INF] Finished resolving. Hack the Planet!
```