### PR TITLE
fix docker build

### DIFF
--- a/.github/workflows/dockerhub-push.yml
+++ b/.github/workflows/dockerhub-push.yml
@@ -35,6 +35,6 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/arm
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: projectdiscovery/shuffledns:latest,projectdiscovery/shuffledns:${{ steps.meta.outputs.TAG }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.5-alpine as build-env
+FROM golang:1.25.5-alpine AS build-env
 RUN apk --no-cache add git
 RUN go install -v github.com/projectdiscovery/shuffledns/cmd/shuffledns@latest
 
@@ -17,5 +17,5 @@ RUN apk --update --no-cache add ldns \
   && apk del .deps
 
 COPY --from=build-env /go/bin/shuffledns /usr/bin/shuffledns
-ENV HOME /
+ENV HOME=/
 ENTRYPOINT ["/usr/bin/shuffledns"]


### PR DESCRIPTION
drop 32-bit ARM support - massdns uses __uint128_t which is unavailable on 32-bit platforms

fixes https://github.com/projectdiscovery/shuffledns/issues/641