### PR TITLE
Update .gitignore and enhance JSON output with root domain extraction

### DIFF
--- a/.github/workflows/dockerhub-push.yml
+++ b/.github/workflows/dockerhub-push.yml
@@ -35,6 +35,6 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/arm
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: projectdiscovery/shuffledns:latest,projectdiscovery/shuffledns:${{ steps.meta.outputs.TAG }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 cmd/shuffledns/shuffledns*
 cmd/shuffledns/build.sh
 dist/
+.claude

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.5-alpine as build-env
+FROM golang:1.25.5-alpine AS build-env
 RUN apk --no-cache add git
 RUN go install -v github.com/projectdiscovery/shuffledns/cmd/shuffledns@latest
 
@@ -17,5 +17,5 @@ RUN apk --update --no-cache add ldns \
   && apk del .deps
 
 COPY --from=build-env /go/bin/shuffledns /usr/bin/shuffledns
-ENV HOME /
+ENV HOME=/
 ENTRYPOINT ["/usr/bin/shuffledns"]

--- a/cmd/shuffledns/actv.json
+++ b/cmd/shuffledns/actv.json
@@ -1,0 +1,1 @@
+{"host":"honey.scanme.sh","input":"scanme.sh"}

--- a/cmd/shuffledns/actv.json
+++ b/cmd/shuffledns/actv.json
@@ -1,1 +1,0 @@
-{"host":"honey.scanme.sh","input":"scanme.sh"}

--- a/pkg/massdns/process.go
+++ b/pkg/massdns/process.go
@@ -445,9 +445,15 @@ func (instance *Instance) writeOutput(store *store.Store) error {
 						if inputDomain == "" {
 							inputDomain = instance.options.Domains[0]
 						}
+					} else {
+						// No domain specified, extract root domain from hostname
+						rootDomain, err := publicsuffix.Domain(hostname)
+						if err == nil {
+							inputDomain = rootDomain
+						}
 					}
 
-					hostnameJson, err := json.Marshal(map[string]interface{}{"input": inputDomain, "hostname": hostname})
+					hostnameJson, err := json.Marshal(map[string]interface{}{"input": inputDomain, "host": hostname})
 					if err != nil {
 						gologger.Error().Msgf("could not marshal output as json: %v", err)
 					}

--- a/pkg/massdns/process.go
+++ b/pkg/massdns/process.go
@@ -428,7 +428,26 @@ func (instance *Instance) writeOutput(store *store.Store) error {
 				var buffer strings.Builder
 
 				if instance.options.Json {
-					hostnameJson, err := json.Marshal(map[string]interface{}{"hostname": hostname})
+					// Extract root domain from hostname to use as input
+					inputDomain := ""
+					if len(instance.options.Domains) > 0 {
+						// Try to find matching root domain from options
+						rootDomain, err := publicsuffix.Domain(hostname)
+						if err == nil {
+							for _, domain := range instance.options.Domains {
+								if rootDomain == domain || strings.HasSuffix(hostname, "."+domain) {
+									inputDomain = domain
+									break
+								}
+							}
+						}
+						// If no match found, use the first domain as fallback
+						if inputDomain == "" {
+							inputDomain = instance.options.Domains[0]
+						}
+					}
+
+					hostnameJson, err := json.Marshal(map[string]interface{}{"input": inputDomain, "hostname": hostname})
 					if err != nil {
 						gologger.Error().Msgf("could not marshal output as json: %v", err)
 					}


### PR DESCRIPTION
During active enumeration such as bruteforce or resolving subdomain. I've seen that while json output. It's only returning the **hostname**.

But it will be better if we print/write output like, 

Subfinder output:
```json
{"host": "honey.scanme.sh", "input": "scanme.sh"}
```

Shuffledns output:
```json
{"hostname": "honey.scanme.sh"}
```

Now, I've updated the **shuffledns** json print/write output similar to subfinder thus we can combine these tool's output more efficiently in our recon workflow:

```json
{"host": "honey.scanme.sh", "input": "scanme.sh"}
```